### PR TITLE
fix cicd for branches

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -54,18 +54,18 @@ jobs:
               run: ./mvnw -ntp package -Pprod -DskipTests
             
             - name: Build and publish docker image
-              if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && ${{ success() }}
+              if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') && success()
               run: |
                   GIT_TAG=:${GITHUB_REF#refs/tags/}
                   DOCKER_TAG=${GIT_TAG#:refs/heads/master}
                   ./mvnw -ntp jib:build -Djib.to.image=homek8s/team-2${DOCKER_TAG} -Djib.to.auth.username="${{ secrets.DOCKER_USERNAME }}" -Djib.to.auth.password="${{ secrets.DOCKER_PASSWORD }}"
 
             - name: Set buildnumber in k8s deployment yaml
-              if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && ${{ success() }}
+              if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') && success()
               run: "sed -i \"s/BUILD_NUMBER:.*/BUILD_NUMBER: '${GITHUB_RUN_NUMBER}'/g\" src/main/kubernetes/deployment.yml"
 
             - name: Add, commit and push modified k8s yaml without triggering new ci run
-              if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && ${{ success() }}
+              if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') && success()
               run: |
                   git config --local user.email "action@github.com"
                   git config --local user.name "GitHub Action"
@@ -73,13 +73,13 @@ jobs:
                   git commit -m "[ci skip] add build number ${GITHUB_RUN_NUMBER} to k8s yaml"
 
             - name: Push changes
-              if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && ${{ success() }}
+              if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') && success()
               uses: ad-m/github-push-action@master
               with:
                 github_token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Sync argocd application
-              if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && ${{ success() }}
+              if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') && success()
               uses: herzogf/action-argocd-sync-app@master
               with:
                 server: ${{ secrets.ARGOCD_SERVER }}


### PR DESCRIPTION
bei (feature) branches werden die docker build, push usw. Schritte jetzt korrekt übersprungen - die volle PIpeline läuft nur für den master branch